### PR TITLE
Fixes KnightOS/KnightOS#201: Directory entries are sorted

### DIFF
--- a/main.c
+++ b/main.c
@@ -34,7 +34,7 @@ void show_help() {
 		"\n"
 		"Examples:\n"
 		"\tTo write ./temp to / on example.rom:\n"
-		"\t\tgenkfs example.rom ./temp"
+		"\t\tgenkfs example.rom ./temp\n"
 	);
 }
 
@@ -167,7 +167,10 @@ void write_recursive(char *model, FILE *rom, uint16_t *parentId, uint16_t *secti
 	struct dirent *entry;
 	DIR *dir = opendir(model);
 	uint16_t parent = *parentId;
-	while ((entry = readdir(dir))) {
+	struct dirent **nameList = NULL;
+	int numEntries = scandir(model, &nameList, NULL, alphasort);
+	for (int i = 0; i < numEntries; i++) {
+		entry = nameList[i];
 		if (entry->d_type == DT_DIR && strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0) {
 			uint16_t elen = strlen(entry->d_name) + 6;
 			uint8_t *fentry = malloc(elen + 3);
@@ -248,7 +251,9 @@ void write_recursive(char *model, FILE *rom, uint16_t *parentId, uint16_t *secti
 			free(target);
 			free(path);
 		}
+		free(nameList[i]);
 	}
+	free(nameList);
 	closedir(dir);
 }
 


### PR DESCRIPTION
This should work, but my system doesn't have the issue in the first place, to know if it actually fixed it. I don't see any reason why it shouldn't.

I also added a newline to the end of the text that's output if no arguments are given so the prompt won't be on the same line.