### PR TITLE
Migrate from asciidoc to scdoc

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -1,6 +1,6 @@
 image: archlinux
 packages:
-  - asciidoc
+  - scdoc
 sources:
   - https://github.com/KnightOS/genkfs
 environment:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-CMakeCache.txt
-CMakeFiles
-cmake_install.cmake
-install_manifest.txt
 *.swp
 *.o
 bin/

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ bin/genkfs:main.o
 	mkdir -p bin/
 	$(CC) $(CFLAGS) $^ -o $@
 
-bin/genkfs.1:genkfs.1.txt
-	a2x --no-xmllint --doctype manpage --format manpage genkfs.1.txt -v -D bin/
+bin/genkfs.1:genkfs.1.scdoc
+	scdoc < genkfs.1.scdoc > bin/genkfs.1
 
 DESTDIR=/usr/local
 BINDIR=$(DESTDIR)/bin/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ genkfs - Writes KFS filesystems into ROM dumps
 
 **Linux, Mac, etc.**
 
-Install make, asciidoc, and a C compiler, then:
+Install make, scdoc, and a C compiler, then:
 
 	$ make
 	# make install # as root

--- a/genkfs.1.scdoc
+++ b/genkfs.1.scdoc
@@ -1,25 +1,19 @@
-/////
-vim:set ts=4 sw=4 tw=82 noet:
-/////
-genkfs (1)
-==========
+GENKFS(1)
 
-Name
-----
+# NAME
+
 genkfs - Writes KFS filesystems into ROM dumps
 
-Synopsis
---------
-'genkfs' _input_ _model_
+# SYNOPSIS
 
-Description
------------
+*genkfs* _input_ _model_
+
+# DESCRIPTION
 
 _input_ is the ROM file you would like to write the filesystem to. _model_ is a
 path to a directory that will be copied into / on the new filesystem.
 
-Symbolic Links
---------------
+# SYMBOLIC LINKS
 
 Symbolic links are supported but have special constraints. Instead of making
 symlinks that make sense in the context of your model filesystem, make symlinks
@@ -31,18 +25,18 @@ filesystem does not have anything interesting at /var/target**.
 In other words, to make the final filesystem have that link from /var/link to
 /var/target, run this command on _model/_:
 
-	ln -s /var/target model/var/link
+```
+ln -s /var/target model/var/link
+```
 
-Examples
---------
+# EXAMPLES
 
-genkfs input.rom ./temp::
+*genkfs input.rom ./temp*
 	Creates a KFS filesystem in input.rom and copies the contents of ./temp to the
 	root of the new filesystem.
 
-Authors
--------
+# AUTHORS
 
 Maintained by Drew DeVault <sir@cmpwn.com>, who is assisted by other open
 source contributors. For more information about genkfs development, see
-<https://github.com/KnightOS/genkfs>.
+https://github.com/KnightOS/genkfs.


### PR DESCRIPTION
Dumping asciidoc for the superior [scdoc](https://sr.ht/~sircmpwn/scdoc/).